### PR TITLE
Fix actions for correct deployment.

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Build release
         run: |
-          trunk build --release --public-url helix-shortcut-quiz
+          trunk build --release --public-url /helix-shortcut-quiz
 
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@v4


### PR DESCRIPTION
It appears my previous PR #30 update on the toolchain had knock-on effects on the page's deployment.
Now the index generated by trunk links to `helix-shortcut-quiz/*` which implicitly expands to `…/helix-shortcut-quiz/helix-shortcut-quiz/*` instead of `…/helix-shortcut-quiz/*`.
Adding the front `/` should reestablish the wanted behavior and fix the linking issue.